### PR TITLE
Add build automation for React

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: "Continuous integration"
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: "Install node.js dependencies"
-          run: npm install
-          working-directory: ./src
+        run: npm install
       
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:  
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -16,10 +16,20 @@ jobs:
       fail-fast: False
       matrix:
         python-version: [3.13]
+        node-version: [14.x]
     
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4
+      
+      - name: "Setup Node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: "Install node.js dependencies"
+          run: npm install
+          working-directory: ./src
       
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "Python Continuous integration"
+name: "Continuous integration"
 
 on:
   push:
@@ -29,6 +29,11 @@ jobs:
 
       - name: "Install node.js dependencies"
         run: npm install
+        working-directory: ./src
+
+      - name: "Build React app"
+        run: npm run build
+        working-directory: ./src
       
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: "Continuous integration"
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Add Continuous Integration and build automation for React. The CI still runs API Testing, which can be expanded. This is related to issue #20 